### PR TITLE
Add inferred display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ var origin = FunctionOrigin(someFn);
 
  - `file`;
  - `line`;
- - `column`.
+ - `column`
+ - `inferredName`.
 
 # License
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function FunctionOrigin(fn) {
   this.file = null;
   this.line = null;
   this.column = null;
+  this.inferredName = null;
 
   binding.SetOrigin(fn, this);
 }

--- a/src/function_origin.cc
+++ b/src/function_origin.cc
@@ -18,6 +18,8 @@ NAN_METHOD(SetOrigin) {
   target->Set(NanNew<String>("column"),
     NanNew<Integer>(fn->GetScriptColumnNumber()));
 
+  target->Set(NanNew<String>("inferredName"), fn->GetInferredName());
+
   NanReturnUndefined();
 }
 

--- a/test.js
+++ b/test.js
@@ -8,9 +8,23 @@ var info = new FunctionOrigin(TestFn);
 assert(/test.js$/.exec(info.file));
 assert.equal(info.line, 3);
 assert.equal(info.column, 15);
+assert.equal(TestFn.name, 'TestFn');
+assert.equal(info.inferredName, '');
 
 info = FunctionOrigin(TestFn);
 
 assert(/test.js$/.exec(info.file));
 assert.equal(info.line, 3);
 assert.equal(info.column, 15);
+assert.equal(TestFn.name, 'TestFn');
+assert.equal(info.inferredName, '');
+
+var assignedFn = function () { }
+
+info = FunctionOrigin(assignedFn);
+
+assert(/test.js$/.exec(info.file));
+assert.equal(info.line, 21);
+assert.equal(info.column, 26);
+assert.equal(assignedFn.name, '');
+assert.equal(info.inferredName, 'assignedFn');


### PR DESCRIPTION
This PR is based on #2 so that needs to merge before this one.
I provided it separately since function names is a separate concern and to give you the choice to merge only the scriptId changes (even though I believe both are important).
- inferredName is important when the function declaration is anonymous
  but the function was assigned to a variable
- in that case the function.name is '' but the inferredName contains the
  name of the variable the function was assigned to
- this is demonstrated in the added tests
- the displayName facilitates debugging and profiling, it's less used
  than inferredName, but was added for completeness
