### PR TITLE
upgrade to nan v2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^1.7.0"
+    "nan": "^2.0.5"
   }
 }

--- a/src/function_origin.cc
+++ b/src/function_origin.cc
@@ -4,28 +4,24 @@
 using namespace v8;
 
 NAN_METHOD(SetOrigin) {
-  NanScope();
-
-  Local<Function> fn = args[0].As<Function>();
-  Local<Object> target = args[1].As<Object>();
+  Local<Function> fn = info[0].As<Function>();
+  Local<Object> target = info[1].As<Object>();
   ScriptOrigin origin = fn->GetScriptOrigin();
 
-  target->Set(NanNew<String>("file"), origin.ResourceName());
+  target->Set(Nan::New<String>("file").ToLocalChecked(), origin.ResourceName());
 
-  target->Set(NanNew<String>("line"),
-    NanNew<Integer>(fn->GetScriptLineNumber()));
+  target->Set(Nan::New<String>("line").ToLocalChecked(),
+    Nan::New<Integer>(fn->GetScriptLineNumber()));
 
-  target->Set(NanNew<String>("column"),
-    NanNew<Integer>(fn->GetScriptColumnNumber()));
+  target->Set(Nan::New<String>("column").ToLocalChecked(),
+    Nan::New<Integer>(fn->GetScriptColumnNumber()));
 
-  target->Set(NanNew<String>("inferredName"), fn->GetInferredName());
-
-  NanReturnUndefined();
+  target->Set(Nan::New<String>("inferredName").ToLocalChecked(), fn->GetInferredName());
 }
 
 static void Init(Handle<Object> exports) {
-  exports->Set(NanNew<String>("SetOrigin"),
-    NanNew<FunctionTemplate>(SetOrigin)->GetFunction());
+  exports->Set(Nan::New<String>("SetOrigin").ToLocalChecked(),
+    Nan::New<FunctionTemplate>(SetOrigin)->GetFunction());
 }
 
 NODE_MODULE(function_origin, Init)


### PR DESCRIPTION
- most changes applied via: https://gist.github.com/thlorenz/7e9d8ad15566c99fd116
- removing HandleScope from NAN_METHOD`s since they are provided in that case already

Passed tests against 0.10, 0.12 and latest iojs.
