### PR TITLE
Fix bound functions

### DIFF
--- a/src/function_origin.cc
+++ b/src/function_origin.cc
@@ -6,8 +6,23 @@ using namespace v8;
 NAN_METHOD(SetOrigin) {
   Local<Function> fn = info[0].As<Function>();
   Local<Object> target = info[1].As<Object>();
-  ScriptOrigin origin = fn->GetScriptOrigin();
 
+  // For bound functions the returned resource name is empty and line and
+  // column numbers are meaningless.
+  // In this case we keep the inferredName of the bound function, but
+  // get all other information from the function from which the
+  // bound function was created.
+  Local<Value> bound;
+  while (true) {
+    bound = fn->GetBoundFunction();
+    if (bound->IsFunction()) {
+      fn = bound.As<Function>();
+    } else {
+      break;
+    }
+  }
+
+  ScriptOrigin origin = fn->GetScriptOrigin();
   target->Set(Nan::New<String>("file").ToLocalChecked(), origin.ResourceName());
 
   target->Set(Nan::New<String>("line").ToLocalChecked(),

--- a/test/runner.js
+++ b/test/runner.js
@@ -28,7 +28,6 @@ info = FunctionOrigin(fixtures.assignedFn);
 assert.equal(info.file, fixturesPath);
 assert.equal(info.line, 5);
 assert.equal(info.column, 26);
-assert.equal(fixtures.assignedFn.name, '');
 assert.equal(info.inferredName, 'assignedFn');
 
 var boundFunction = fixtures.TestFn.bind({});

--- a/test/runner.js
+++ b/test/runner.js
@@ -30,3 +30,10 @@ assert.equal(info.line, 5);
 assert.equal(info.column, 26);
 assert.equal(fixtures.assignedFn.name, '');
 assert.equal(info.inferredName, 'assignedFn');
+
+var boundFunction = fixtures.TestFn.bind({});
+info = FunctionOrigin(boundFunction);
+assert.equal(info.file, fixturesPath);
+assert.equal(info.line, 2);
+assert.equal(info.column, 15);
+assert.equal(info.inferredName, '');


### PR DESCRIPTION
- without this fix accessing the `file` property of the returned
function origin of a bound function crashes the process

Additionally removed a test that no longer passes with latest v8 as it has gotten smarter:

- v8 has improved and with latest node the function name is resolved to
'assignedFunction'
- additionally that assert wasn't really testing function-origin functionality